### PR TITLE
Update example branch name sanitization docs tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ Default worktree base: `~/code/airflow-worktree`
 abm add my-feature --create-branch
 
 # Use branch name directly (slash sanitized automatically)
-abm add feature/version-indicator --branch feature/version-indicator
-# → Creates project "feature-version-indicator" for branch "feature/version-indicator"
+abm add feature/awesome-improvement --branch feature/awesome-improvement
+# → Creates project "feature-awesome-improvement" for branch "feature/awesome-improvement"
 
 # Enter breeze shell
 abm shell my-feature

--- a/tests/test_cli_basic.py
+++ b/tests/test_cli_basic.py
@@ -137,12 +137,12 @@ def test_project_name_slash_sanitization() -> None:
     """Test that project names with slashes are sanitized correctly.
 
     This prevents creating nested directories when users specify branch names
-    like 'feature/version-indicator' as the project name.
+    like 'feature/awesome-improvement' as the project name.
     """
     # Test the sanitization logic directly
-    name_with_slash = "feature/version-indicator"
+    name_with_slash = "feature/awesome-improvement"
     sanitized = name_with_slash.replace("/", "-")
-    assert sanitized == "feature-version-indicator"
+    assert sanitized == "feature-awesome-improvement"
     assert "/" not in sanitized
 
     # Test multiple slashes


### PR DESCRIPTION
The branch name used in documentation and test examples included my working branch name.
I updated them to use a neutral example branch name (feature/awesome-improvement) instead.

follow up: #1 