### PR TITLE
Add `abm exec` command to join running Airflow container

### DIFF
--- a/src/airflow_breeze_manager/cli.py
+++ b/src/airflow_breeze_manager/cli.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import builtins
 import os
 import shutil
+import subprocess
+import sys
 import webbrowser
 from datetime import datetime
 from pathlib import Path
@@ -11,7 +13,7 @@ from typing import Annotated
 import typer
 from rich.table import Table
 
-from airflow_breeze_manager.cli_helpers import cleanup_breeze_containers
+from airflow_breeze_manager.cli_helpers import cleanup_breeze_containers, find_airflow_container
 from airflow_breeze_manager.constants import (
     ABM_CONFIG_FILE,
     ABM_DIR,
@@ -1015,6 +1017,61 @@ def shell(
         ],
         env,
     )
+
+
+@app.command(name="exec")
+def exec_command(
+    project_name: Annotated[
+        str | None,
+        typer.Argument(help="Project name (auto-detected if in project directory)"),
+    ] = None,
+    exec_args: Annotated[
+        builtins.list[str] | None,
+        typer.Argument(help="Additional arguments to pass to the shell"),
+    ] = None,
+) -> None:
+    """Join the interactive shell of a running Airflow container.
+
+    This command is useful for connecting to an already running container,
+    for example one started with 'abm shell' or 'abm start-airflow'.
+
+    Examples:
+        abm exec
+        abm exec my-project bash
+        abm exec my-project python -c "print('hello')"
+    """
+    project, _ = require_project(project_name)
+
+    if project.frozen:
+        console.print(
+            f"[yellow]Project '{project.name}' is frozen. Thaw it first with 'abm thaw {project.name}'[/yellow]"
+        )
+        raise typer.Exit(1)
+
+    worktree_path = project.worktree_path
+    container_id = find_airflow_container(worktree_path)
+
+    if not container_id:
+        console.print(f"[red]No running Airflow container found for project '{project.name}'[/red]")
+        console.print("[dim]Start the container first with 'abm shell' or 'abm start-airflow'[/dim]")
+        raise typer.Exit(1)
+
+    # Build the docker exec command
+    cmd_to_run = [
+        "docker",
+        "exec",
+        "-it",
+        container_id,
+        "/opt/airflow/scripts/docker/entrypoint_exec.sh",
+    ]
+
+    if exec_args:
+        cmd_to_run.extend(exec_args)
+
+    console.print(f"[green]Joining Airflow container for '{project.name}'...[/green]")
+
+    process = subprocess.run(cmd_to_run, check=False)
+    sys.exit(process.returncode)
 
 
 @app.command()

--- a/src/airflow_breeze_manager/cli_helpers.py
+++ b/src/airflow_breeze_manager/cli_helpers.py
@@ -7,6 +7,54 @@ from rich.console import Console
 console = Console()
 
 
+def find_airflow_container(worktree_path: str) -> str | None:
+    """Find the running Airflow container for a specific ABM project.
+
+    Args:
+        worktree_path: Path to the project worktree
+
+    Returns:
+        Container ID if found, None otherwise
+    """
+    try:
+        # Find running containers with the airflow service
+        result = subprocess.run(
+            [
+                "docker",
+                "ps",
+                "--filter",
+                "name=airflow",
+                "--filter",
+                "status=running",
+                "--format",
+                "{{.ID}}\t{{.Labels}}",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        for line in result.stdout.splitlines():
+            if not line.strip():
+                continue
+            parts = line.split("\t", 1)
+            if len(parts) < 2:
+                continue
+            container_id, labels = parts
+
+            # Check if this container belongs to the specified worktree
+            # Docker compose labels include the working directory
+            if f"com.docker.compose.project.working_dir={worktree_path}" in labels:
+                return container_id
+
+        return None
+    except subprocess.CalledProcessError:
+        return None
+    except FileNotFoundError:
+        console.print("[red]Docker not found. Is Docker installed?[/red]")
+        return None
+
+
 def cleanup_breeze_containers() -> int:
     """Clean up any orphaned breeze containers."""
     try:

--- a/tests/test_cli_basic.py
+++ b/tests/test_cli_basic.py
@@ -1,16 +1,149 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import tempfile
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from typer.testing import CliRunner
 
 from airflow_breeze_manager.cli import app
+from airflow_breeze_manager.cli_helpers import find_airflow_container
 from airflow_breeze_manager.models import ProjectMetadata, ProjectPorts
 
 runner = CliRunner()
+
+
+def test_find_airflow_container_found() -> None:
+    """Test find_airflow_container when container is found."""
+    worktree_path = "/tmp/my-worktree"
+    container_id = "abc123def456"
+
+    # Mock docker ps output
+    mock_output = f"{container_id}\tcom.docker.compose.project.working_dir={worktree_path},other=label"
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            stdout=mock_output,
+            returncode=0,
+        )
+        result = find_airflow_container(worktree_path)
+
+    assert result == container_id
+    mock_run.assert_called_once()
+
+
+def test_find_airflow_container_not_found() -> None:
+    """Test find_airflow_container when no container is found."""
+    worktree_path = "/tmp/my-worktree"
+
+    # Mock empty docker ps output
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            stdout="",
+            returncode=0,
+        )
+        result = find_airflow_container(worktree_path)
+
+    assert result is None
+
+
+def test_find_airflow_container_different_worktree() -> None:
+    """Test find_airflow_container when container belongs to different worktree."""
+    worktree_path = "/tmp/my-worktree"
+    other_worktree = "/tmp/other-worktree"
+    container_id = "abc123def456"
+
+    # Mock docker ps output with different worktree
+    mock_output = f"{container_id}\tcom.docker.compose.project.working_dir={other_worktree},other=label"
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            stdout=mock_output,
+            returncode=0,
+        )
+        result = find_airflow_container(worktree_path)
+
+    assert result is None
+
+
+def test_find_airflow_container_docker_error() -> None:
+    """Test find_airflow_container when docker command fails."""
+    worktree_path = "/tmp/my-worktree"
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.side_effect = subprocess.CalledProcessError(1, "docker")
+        result = find_airflow_container(worktree_path)
+
+    assert result is None
+
+
+def test_cli_exec_no_project() -> None:
+    """Test exec command with non-existent project."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        abm_dir = Path(tmpdir) / ".airflow-breeze-manager"
+        projects_dir = abm_dir / "projects"
+        projects_dir.mkdir(parents=True)
+
+        with patch("airflow_breeze_manager.utils.PROJECTS_DIR", projects_dir):
+            result = runner.invoke(app, ["exec", "nonexistent-project"])
+            assert result.exit_code == 1
+            assert "not found" in result.output.lower()
+
+
+def test_cli_exec_no_container() -> None:
+    """Test exec command when no container is running."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        abm_dir = Path(tmpdir) / ".airflow-breeze-manager"
+        projects_dir = abm_dir / "projects"
+        projects_dir.mkdir(parents=True)
+
+        # Create a test project
+        project_dir = projects_dir / "my-project"
+        project_dir.mkdir()
+        metadata = ProjectMetadata(
+            name="my-project",
+            branch="feature/test",
+            worktree_path="/tmp/my-project",
+            ports=ProjectPorts.default(),
+            description="Test project",
+        )
+        with open(project_dir / ".abm", "w") as f:
+            json.dump(metadata.to_dict(), f)
+
+        with patch("airflow_breeze_manager.utils.PROJECTS_DIR", projects_dir):
+            with patch("airflow_breeze_manager.cli.find_airflow_container", return_value=None):
+                result = runner.invoke(app, ["exec", "my-project"])
+                assert result.exit_code == 1
+                assert "no running" in result.output.lower()
+
+
+def test_cli_exec_frozen_project() -> None:
+    """Test exec command on a frozen project."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        abm_dir = Path(tmpdir) / ".airflow-breeze-manager"
+        projects_dir = abm_dir / "projects"
+        projects_dir.mkdir(parents=True)
+
+        # Create a frozen test project
+        project_dir = projects_dir / "my-project"
+        project_dir.mkdir()
+        metadata = ProjectMetadata(
+            name="my-project",
+            branch="feature/test",
+            worktree_path="/tmp/my-project",
+            ports=ProjectPorts.default(),
+            description="Test project",
+            frozen=True,
+        )
+        with open(project_dir / ".abm", "w") as f:
+            json.dump(metadata.to_dict(), f)
+
+        with patch("airflow_breeze_manager.utils.PROJECTS_DIR", projects_dir):
+            result = runner.invoke(app, ["exec", "my-project"])
+            assert result.exit_code == 1
+            assert "frozen" in result.output.lower()
 
 
 def test_cli_list_empty() -> None:


### PR DESCRIPTION
## Why

`breeze exec` is one of the commands I use most frequently when contributing. Because I don't need to terminate the `breeze` container instance started by `shell` command, I can directly `exec` into the same container to run some command simultaneously.

## What

Add the `abm exec` command.