### PR TITLE
Add `abm api` command for direct Airflow REST API calls

### DIFF
--- a/src/airflow_breeze_manager/api.py
+++ b/src/airflow_breeze_manager/api.py
@@ -1,0 +1,261 @@
+"""Lightweight Airflow REST API client for ABM projects."""
+
+from __future__ import annotations
+
+import base64
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+
+def _build_auth_header(username: str, password: str) -> str:
+    """Build Basic Auth header value."""
+    credentials = base64.b64encode(f"{username}:{password}".encode()).decode()
+    return f"Basic {credentials}"
+
+
+def make_request(
+    base_url: str,
+    endpoint: str,
+    method: str = "GET",
+    params: dict[str, Any] | None = None,
+    json_data: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+    username: str = "airflow",
+    password: str = "airflow",
+    raw_endpoint: bool = False,
+    api_version: str = "v1",
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    """Make an HTTP request to Airflow REST API.
+
+    Args:
+        base_url: Base URL like http://localhost:28180
+        endpoint: API endpoint like "dags" or "dags/my_dag"
+        method: HTTP method (GET, POST, PATCH, PUT, DELETE)
+        params: Query parameters
+        json_data: JSON body for POST/PATCH/PUT
+        headers: Additional headers
+        username: Basic auth username
+        password: Basic auth password
+        raw_endpoint: If True, use endpoint as-is without /api/vX prefix
+        api_version: API version prefix (v1 or v2)
+        timeout: Request timeout in seconds
+
+    Returns:
+        Dict with 'status_code', 'headers', 'body' keys.
+    """
+    # Build the URL
+    endpoint = endpoint.lstrip("/")
+    if raw_endpoint:
+        url = f"{base_url}/{endpoint}"
+    else:
+        url = f"{base_url}/api/{api_version}/{endpoint}"
+
+    # Add query parameters
+    if params:
+        url = f"{url}?{urllib.parse.urlencode(params)}"
+
+    # Prepare request body
+    data = None
+    if json_data is not None:
+        data = json.dumps(json_data).encode("utf-8")
+
+    req = urllib.request.Request(url, data=data, method=method)
+
+    # Set headers
+    req.add_header("Authorization", _build_auth_header(username, password))
+    req.add_header("Accept", "application/json")
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    if headers:
+        for key, value in headers.items():
+            req.add_header(key, value)
+
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            body_bytes = response.read()
+            try:
+                body = json.loads(body_bytes)
+            except (json.JSONDecodeError, ValueError):
+                body = body_bytes.decode("utf-8", errors="replace")
+            return {
+                "status_code": response.status,
+                "headers": dict(response.headers),
+                "body": body,
+            }
+    except urllib.error.HTTPError as e:
+        body_bytes = e.read()
+        try:
+            body = json.loads(body_bytes)
+        except (json.JSONDecodeError, ValueError):
+            body = body_bytes.decode("utf-8", errors="replace")
+        return {
+            "status_code": e.code,
+            "headers": dict(e.headers) if e.headers else {},
+            "body": body,
+        }
+    except urllib.error.URLError as e:
+        return {
+            "status_code": 0,
+            "headers": {},
+            "body": {"error": str(e.reason)},
+        }
+
+
+def detect_api_version(
+    base_url: str,
+    username: str = "airflow",
+    password: str = "airflow",
+    timeout: float = 5.0,
+) -> str:
+    """Detect Airflow API version by probing endpoints.
+
+    Tries /api/v2/version first (Airflow 3.x), falls back to /api/v1/version (Airflow 2.x).
+
+    Returns:
+        "v2" or "v1"
+    """
+    for version in ("v2", "v1"):
+        result = make_request(
+            base_url,
+            "version",
+            api_version=version,
+            username=username,
+            password=password,
+            timeout=timeout,
+        )
+        if result["status_code"] == 200:
+            return version
+
+    # Default to v1 if neither responds
+    return "v1"
+
+
+def get_openapi_spec(
+    base_url: str,
+    api_version: str,
+    username: str = "airflow",
+    password: str = "airflow",
+    timeout: float = 10.0,
+) -> dict[str, Any] | None:
+    """Fetch the OpenAPI spec for endpoint listing.
+
+    Returns:
+        Parsed OpenAPI spec dict, or None if unavailable.
+    """
+    # Airflow serves OpenAPI spec at /api/v1/openapi.json (v1) or /api/v2/openapi.json (v2)
+    # Also try the alternative path /api/vX/openapi.yaml (returns JSON sometimes)
+    for path in (f"api/{api_version}/openapi.json", f"api/{api_version}/openapi.yaml"):
+        result = make_request(
+            base_url,
+            path,
+            raw_endpoint=True,
+            username=username,
+            password=password,
+            timeout=timeout,
+        )
+        if result["status_code"] == 200 and isinstance(result["body"], dict):
+            return result["body"]
+    return None
+
+
+def parse_fields(
+    fields: list[str] | None,
+    raw_fields: list[str] | None,
+) -> dict[str, Any]:
+    """Parse -F (typed) and -f (raw string) fields into a dict.
+
+    -F fields auto-detect type: int, float, bool, null, or string.
+    -f fields are always strings.
+
+    Args:
+        fields: Typed fields from -F, e.g. ["limit=10", "only_active=true"]
+        raw_fields: Raw string fields from -f, e.g. ["key=my_var", "value=x"]
+
+    Returns:
+        Merged dict of field values.
+    """
+    result: dict[str, Any] = {}
+
+    for field_list, typed in ((fields, True), (raw_fields, False)):
+        if not field_list:
+            continue
+        for item in field_list:
+            if "=" not in item:
+                raise ValueError(f"Invalid field format (expected key=value): {item}")
+            key, value = item.split("=", 1)
+            if typed:
+                result[key] = _coerce_value(value)
+            else:
+                result[key] = value
+
+    return result
+
+
+def _coerce_value(value: str) -> Any:
+    """Coerce a string value to its most specific Python type.
+
+    Handles: int, float, bool (true/false), null/none, or string.
+    """
+    lower = value.lower()
+    if lower == "true":
+        return True
+    if lower == "false":
+        return False
+    if lower in ("null", "none"):
+        return None
+
+    # Try int
+    try:
+        return int(value)
+    except ValueError:
+        pass
+
+    # Try float
+    try:
+        return float(value)
+    except ValueError:
+        pass
+
+    return value
+
+
+def format_endpoint_list(
+    spec: dict[str, Any],
+    filter_pattern: str | None = None,
+) -> list[dict[str, str]]:
+    """Extract endpoint list from OpenAPI spec.
+
+    Args:
+        spec: Parsed OpenAPI spec dict.
+        filter_pattern: Optional substring filter for paths.
+
+    Returns:
+        List of dicts with 'method', 'path', 'summary' keys.
+    """
+    endpoints: list[dict[str, str]] = []
+    paths = spec.get("paths", {})
+
+    for path, methods in sorted(paths.items()):
+        if filter_pattern and filter_pattern.lower() not in path.lower():
+            continue
+        if not isinstance(methods, dict):
+            continue
+        for method in ("get", "post", "put", "patch", "delete"):
+            if method in methods:
+                operation = methods[method]
+                summary = ""
+                if isinstance(operation, dict):
+                    summary = operation.get("summary", "")
+                endpoints.append(
+                    {
+                        "method": method.upper(),
+                        "path": path,
+                        "summary": summary,
+                    }
+                )
+
+    return endpoints

--- a/src/airflow_breeze_manager/cli.py
+++ b/src/airflow_breeze_manager/cli.py
@@ -19,12 +19,15 @@ from airflow_breeze_manager.constants import (
     ABM_DIR,
     DEFAULT_AIRFLOW_REPO,
     DEFAULT_WORKTREE_BASE,
+    HEADLESS_POLL_INTERVAL,
+    HEADLESS_READY_TIMEOUT,
     PROJECTS_DIR,
     SCHEMA_VERSION,
     SYMLINKED_FILES,
 )
 from airflow_breeze_manager.models import GlobalConfig, ProjectMetadata
 from airflow_breeze_manager.output import (
+    API_ERROR,
     BRANCH_NOT_FOUND,
     DOCKER_ERROR,
     INVALID_INPUT,
@@ -2088,6 +2091,15 @@ def start_airflow(
         builtins.list[str] | None,
         typer.Option("--debug-components", help="Components to enable remote debugging for"),
     ] = None,
+    headless: Annotated[
+        bool,
+        typer.Option(
+            "--headless",
+            help="Run Airflow without a terminal multiplexer (no TTY needed). "
+            "Uses 'breeze shell' + 'airflow standalone' to start all Airflow processes. "
+            "Automatically enabled when no TTY is available or in --json mode.",
+        ),
+    ] = False,
     extra_args: Annotated[
         builtins.list[str] | None,
         typer.Argument(help="Extra arguments passed to breeze start-airflow"),
@@ -2123,6 +2135,13 @@ def start_airflow(
     # Set compose project name for container isolation
     compose_project = get_docker_compose_project_name(project.name)
     env["COMPOSE_PROJECT_NAME"] = compose_project
+
+    # Headless mode: auto-detect when no TTY or in JSON mode
+    use_headless = headless or is_json_mode() or not sys.stdin.isatty()
+
+    if use_headless:
+        _start_airflow_headless(project, project_dir, worktree_path, env, compose_project)
+        return
 
     breeze_cmd = [
         "breeze",
@@ -2191,6 +2210,325 @@ def start_airflow(
         breeze_cmd,
         env,
     )
+
+
+def _wait_for_ready(port: int, timeout: int = HEADLESS_READY_TIMEOUT) -> bool:
+    """Poll Airflow API until ready."""
+    import time
+    import urllib.request
+
+    url = f"http://localhost:{port}/api/v2/version"
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            with urllib.request.urlopen(url, timeout=5) as resp:
+                if resp.status == 200:
+                    return True
+        except Exception:
+            pass
+        time.sleep(HEADLESS_POLL_INTERVAL)
+    return False
+
+
+def _start_airflow_headless(
+    project: ProjectMetadata,
+    project_dir: Path,
+    worktree_path: Path,
+    env: dict[str, str],
+    compose_project: str,
+) -> None:
+    """Start Airflow in headless mode using 'breeze shell' + 'airflow standalone'.
+
+    Uses 'breeze shell' (which already forwards ports) to run 'airflow standalone',
+    which starts scheduler, dag-processor, api-server, and triggerer in a single
+    process. No mprocs/tmux needed, no TTY needed.
+    """
+    breeze_cmd = [
+        "breeze",
+        "shell",
+        "--python",
+        project.python_version,
+        "--backend",
+        project.backend,
+        "--quiet",
+        "--tty",
+        "disabled",
+        "airflow",
+        "standalone",
+    ]
+
+    log_file = project_dir / "headless.log"
+
+    # Run in background, capturing output to log file
+    with open(log_file, "w") as log_fh:
+        process = subprocess.Popen(
+            breeze_cmd,
+            cwd=worktree_path,
+            env=env,
+            stdout=log_fh,
+            stderr=subprocess.STDOUT,
+        )
+
+    # Poll for readiness
+    ready = _wait_for_ready(project.ports.webserver)
+
+    result = {
+        "project": project.to_rich_dict(),
+        "pid": process.pid,
+        "ready": ready,
+        "urls": {
+            "webserver": f"http://localhost:{project.ports.webserver}",
+        },
+        "log_file": str(log_file),
+        "compose_project_name": compose_project,
+    }
+
+    if is_json_mode():
+        json_success(result)
+
+    if ready:
+        console.print(f"[green]Airflow is ready for '{project.name}'![/green]")
+        console.print(f"  API: http://localhost:{project.ports.webserver}")
+        console.print(f"  PID: {process.pid}")
+        console.print(f"  Logs: {log_file}")
+    else:
+        console.print("[yellow]Airflow did not become ready within timeout[/yellow]")
+        console.print(f"  Check logs: {log_file}")
+
+
+@app.command("stop-airflow", rich_help_panel="Environment Commands")
+def stop_airflow(
+    project_name: Annotated[
+        str | None,
+        typer.Argument(help="Project name (auto-detected if in project directory)"),
+    ] = None,
+) -> None:
+    """Stop a running Airflow instance for a project."""
+    project, _project_dir = require_project(project_name)
+    stop_project_containers(project.worktree_path)
+    if is_json_mode():
+        json_success({"project": project.name, "stopped": True})
+    console.print(f"[green]Stopped Airflow for '{project.name}'[/green]")
+
+
+@app.command(rich_help_panel="Environment Commands")
+def api(
+    endpoint: Annotated[
+        str | None,
+        typer.Argument(help="API endpoint (e.g. 'dags', 'dags/my_dag') or 'ls' to list endpoints"),
+    ] = None,
+    project_name: Annotated[
+        str | None,
+        typer.Option("--project", "-p", help="Project name (auto-detected if in project directory)"),
+    ] = None,
+    method: Annotated[
+        str,
+        typer.Option("--method", "-X", help="HTTP method"),
+    ] = "GET",
+    field: Annotated[
+        builtins.list[str] | None,
+        typer.Option("--field", "-F", help="Typed field (key=value, auto-coerces types)"),
+    ] = None,
+    raw_field: Annotated[
+        builtins.list[str] | None,
+        typer.Option("--raw-field", "-f", help="Raw string field (key=value, always string)"),
+    ] = None,
+    header: Annotated[
+        builtins.list[str] | None,
+        typer.Option("--header", "-H", help="Additional header (key:value)"),
+    ] = None,
+    body: Annotated[
+        str | None,
+        typer.Option("--body", help="Raw JSON body"),
+    ] = None,
+    include: Annotated[
+        bool,
+        typer.Option("--include", "-i", help="Include HTTP status and headers in output"),
+    ] = False,
+    raw: Annotated[
+        bool,
+        typer.Option("--raw", help="Use endpoint as-is without /api/vX prefix"),
+    ] = False,
+    username: Annotated[
+        str,
+        typer.Option("--username", "-U", help="Airflow username"),
+    ] = "airflow",
+    password: Annotated[
+        str,
+        typer.Option("--password", "-P", help="Airflow password"),
+    ] = "airflow",
+    filter_pattern: Annotated[
+        str | None,
+        typer.Option("--filter", help="Filter pattern for 'ls' subcommand"),
+    ] = None,
+) -> None:
+    """Make direct requests to an ABM project's Airflow REST API.
+
+    Similar to `gh api` for GitHub. The API version prefix (/api/v1 or /api/v2) is
+    auto-detected based on the running Airflow version.
+
+    \b
+    Examples:
+      abm api dags                              # GET /api/v1/dags
+      abm api dags/my_dag                       # GET /api/v1/dags/my_dag
+      abm api health --raw                      # GET /health (no version prefix)
+      abm api dags -F limit=10                  # GET with query params
+      abm api dags/my_dag -X PATCH -F is_paused=true
+      abm api variables -X POST -f key=test -f value=hello
+      abm api dags -i                           # Include HTTP headers
+      abm api ls                                # List available endpoints
+      abm api ls --filter variable              # Filter endpoints by pattern
+    """
+    import json as json_mod
+
+    from airflow_breeze_manager.api import (
+        detect_api_version,
+        format_endpoint_list,
+        get_openapi_spec,
+        make_request,
+        parse_fields,
+    )
+
+    if endpoint is None:
+        if is_json_mode():
+            json_error("Endpoint is required. Use 'abm api <endpoint>' or 'abm api ls'.", INVALID_INPUT)
+        console.print("[red]Endpoint is required. Use 'abm api <endpoint>' or 'abm api ls'.[/red]")
+        raise typer.Exit(1)
+
+    project, _project_dir = require_project(project_name)
+
+    base_url = f"http://localhost:{project.ports.webserver}"
+
+    # Detect API version (unless --raw, which skips the prefix entirely)
+    api_version = "v1"
+    if not raw:
+        api_version = detect_api_version(base_url, username=username, password=password)
+
+    # Handle 'ls' subcommand — list available endpoints from OpenAPI spec
+    if endpoint == "ls":
+        spec = get_openapi_spec(base_url, api_version, username=username, password=password)
+        if spec is None:
+            if is_json_mode():
+                json_error("Could not fetch OpenAPI spec. Is Airflow running?", API_ERROR)
+            console.print("[red]Could not fetch OpenAPI spec. Is Airflow running?[/red]")
+            raise typer.Exit(1)
+
+        endpoints = format_endpoint_list(spec, filter_pattern=filter_pattern)
+
+        if is_json_mode():
+            json_success({"endpoints": endpoints, "api_version": api_version})
+
+        if not endpoints:
+            console.print("[yellow]No endpoints found matching filter.[/yellow]")
+            raise typer.Exit(0)
+
+        table = Table(title=f"Airflow API Endpoints ({api_version})")
+        table.add_column("Method", style="bold cyan", width=8)
+        table.add_column("Path", style="green")
+        table.add_column("Summary", style="dim")
+        for ep in endpoints:
+            table.add_row(ep["method"], ep["path"], ep["summary"])
+        console.print(table)
+        raise typer.Exit(0)
+
+    # Parse fields
+    try:
+        parsed_fields = parse_fields(field, raw_field)
+    except ValueError as e:
+        if is_json_mode():
+            json_error(str(e), INVALID_INPUT)
+        console.print(f"[red]{e}[/red]")
+        raise typer.Exit(1)
+
+    # Parse additional headers
+    extra_headers: dict[str, str] = {}
+    if header:
+        for h in header:
+            if ":" not in h:
+                msg = f"Invalid header format (expected key:value): {h}"
+                if is_json_mode():
+                    json_error(msg, INVALID_INPUT)
+                console.print(f"[red]{msg}[/red]")
+                raise typer.Exit(1)
+            key, value = h.split(":", 1)
+            extra_headers[key.strip()] = value.strip()
+
+    # Determine params vs json_data based on method
+    params = None
+    json_data = None
+
+    if body:
+        # Explicit --body takes precedence
+        try:
+            json_data = json_mod.loads(body)
+        except json_mod.JSONDecodeError as e:
+            msg = f"Invalid JSON body: {e}"
+            if is_json_mode():
+                json_error(msg, INVALID_INPUT)
+            console.print(f"[red]{msg}[/red]")
+            raise typer.Exit(1)
+        # Fields merge into body if present
+        if parsed_fields:
+            if isinstance(json_data, dict):
+                json_data.update(parsed_fields)
+    elif parsed_fields:
+        if method.upper() in ("GET", "DELETE", "HEAD", "OPTIONS"):
+            params = parsed_fields
+        else:
+            json_data = parsed_fields
+
+    # Make the request
+    result = make_request(
+        base_url=base_url,
+        endpoint=endpoint,
+        method=method.upper(),
+        params=params,
+        json_data=json_data,
+        headers=extra_headers if extra_headers else None,
+        username=username,
+        password=password,
+        raw_endpoint=raw,
+        api_version=api_version,
+    )
+
+    # Handle connection errors (status_code 0)
+    if result["status_code"] == 0:
+        error_body = result["body"]
+        error_msg = error_body.get("error", str(error_body)) if isinstance(error_body, dict) else str(error_body)
+        msg = f"Connection failed: {error_msg}"
+        if is_json_mode():
+            json_error(msg, API_ERROR)
+        console.print(f"[red]{msg}[/red]")
+        raise typer.Exit(1)
+
+    # JSON mode: structured output
+    if is_json_mode():
+        json_success(
+            {
+                "status_code": result["status_code"],
+                "headers": result["headers"],
+                "body": result["body"],
+                "api_version": api_version,
+            }
+        )
+
+    # Rich mode: format output
+    if include:
+        console.print(f"[bold]HTTP {result['status_code']}[/bold]")
+        for key, value in result["headers"].items():
+            console.print(f"[dim]{key}: {value}[/dim]")
+        console.print()
+
+    # Pretty-print body
+    response_body = result["body"]
+    if isinstance(response_body, (dict, builtins.list)):
+        console.print_json(json_mod.dumps(response_body, indent=2))
+    else:
+        console.print(str(response_body))
+
+    # Exit with non-zero for HTTP errors
+    if result["status_code"] >= 400:
+        raise typer.Exit(1)
 
 
 if __name__ == "__main__":

--- a/src/airflow_breeze_manager/constants.py
+++ b/src/airflow_breeze_manager/constants.py
@@ -62,6 +62,10 @@ SYMLINKED_FILES = [
 # ABM automatically creates a symlink from each worktree to the main repo's .cursor
 # directory during `abm add`, so Cursor rules work immediately in all projects.
 
+# Headless mode settings
+HEADLESS_READY_TIMEOUT = 180  # seconds to wait for Airflow to become ready
+HEADLESS_POLL_INTERVAL = 3  # seconds between readiness polls
+
 # Breeze environment variable prefixes that should be isolated per project
 BREEZE_ENV_PREFIXES = [
     "WEB_HOST_PORT",

--- a/src/airflow_breeze_manager/output.py
+++ b/src/airflow_breeze_manager/output.py
@@ -27,6 +27,7 @@ DOCKER_ERROR = "DOCKER_ERROR"
 INVALID_WORKTREE = "INVALID_WORKTREE"
 INVALID_INPUT = "INVALID_INPUT"
 COMMAND_FAILED = "COMMAND_FAILED"
+API_ERROR = "API_ERROR"
 
 # ---------------------------------------------------------------------------
 # Module-level state — set by the Typer app callback in cli.py

--- a/src/airflow_breeze_manager/utils.py
+++ b/src/airflow_breeze_manager/utils.py
@@ -338,16 +338,19 @@ def get_running_containers() -> dict[str, dict[str, Any]]:
                     project_containers[project_name]["services"].append(service_name)
 
                     # Check if running start-airflow (has tmux/mprocs and multiple airflow processes)
+                    # Also detects headless mode (airflow processes without a terminal multiplexer)
                     try:
                         top_output = container.top()
                         processes = top_output.get("Processes", [])
-                        # Look for tmux or mprocs in process list
-                        # Breeze defaults to mprocs since Nov 2025, but tmux is still supported
                         for process in processes:
                             # Process is a list: [PID, USER, TIME, COMMAND]
                             if len(process) > 3:
                                 cmd_str = str(process[3]).lower()
                                 if "tmux" in cmd_str or "mprocs" in cmd_str:
+                                    project_containers[project_name]["is_start_airflow"] = True
+                                    break
+                                # Headless mode: airflow processes running directly
+                                if "airflow" in cmd_str and ("scheduler" in cmd_str or "api-server" in cmd_str):
                                     project_containers[project_name]["is_start_airflow"] = True
                                     break
                     except Exception:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,698 @@
+"""Tests for the ABM API module."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from airflow_breeze_manager.api import (
+    _coerce_value,
+    detect_api_version,
+    format_endpoint_list,
+    make_request,
+    parse_fields,
+)
+from airflow_breeze_manager.cli import app
+from airflow_breeze_manager.models import ProjectMetadata, ProjectPorts
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Tests for _coerce_value
+# ---------------------------------------------------------------------------
+
+
+class TestCoerceValue:
+    def test_bool_true(self) -> None:
+        assert _coerce_value("true") is True
+        assert _coerce_value("True") is True
+        assert _coerce_value("TRUE") is True
+
+    def test_bool_false(self) -> None:
+        assert _coerce_value("false") is False
+        assert _coerce_value("False") is False
+
+    def test_null(self) -> None:
+        assert _coerce_value("null") is None
+        assert _coerce_value("none") is None
+        assert _coerce_value("None") is None
+
+    def test_int(self) -> None:
+        assert _coerce_value("10") == 10
+        assert _coerce_value("0") == 0
+        assert _coerce_value("-5") == -5
+
+    def test_float(self) -> None:
+        assert _coerce_value("3.14") == 3.14
+        assert _coerce_value("-0.5") == -0.5
+
+    def test_string(self) -> None:
+        assert _coerce_value("hello") == "hello"
+        assert _coerce_value("") == ""
+        assert _coerce_value("foo bar") == "foo bar"
+
+
+# ---------------------------------------------------------------------------
+# Tests for parse_fields
+# ---------------------------------------------------------------------------
+
+
+class TestParseFields:
+    def test_typed_fields(self) -> None:
+        result = parse_fields(["limit=10", "only_active=true"], None)
+        assert result == {"limit": 10, "only_active": True}
+
+    def test_raw_fields(self) -> None:
+        result = parse_fields(None, ["key=my_var", "value=hello"])
+        assert result == {"key": "my_var", "value": "hello"}
+
+    def test_raw_fields_preserve_numeric_strings(self) -> None:
+        result = parse_fields(None, ["port=8080"])
+        assert result == {"port": "8080"}
+        assert isinstance(result["port"], str)
+
+    def test_mixed_fields(self) -> None:
+        result = parse_fields(["limit=10"], ["key=my_var"])
+        assert result == {"limit": 10, "key": "my_var"}
+
+    def test_empty_fields(self) -> None:
+        result = parse_fields(None, None)
+        assert result == {}
+
+    def test_value_with_equals(self) -> None:
+        result = parse_fields(None, ["query=a=b"])
+        assert result == {"query": "a=b"}
+
+    def test_invalid_field_format(self) -> None:
+        with pytest.raises(ValueError, match="Invalid field format"):
+            parse_fields(["no_equals_sign"], None)
+
+
+# ---------------------------------------------------------------------------
+# Tests for make_request
+# ---------------------------------------------------------------------------
+
+
+class TestMakeRequest:
+    def test_get_request(self) -> None:
+        """Test basic GET request construction."""
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.headers = {"Content-Type": "application/json"}
+        mock_response.read.return_value = b'{"dags": []}'
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_response) as mock_urlopen:
+            result = make_request("http://localhost:28180", "dags")
+
+        assert result["status_code"] == 200
+        assert result["body"] == {"dags": []}
+
+        # Verify the URL was constructed correctly
+        req = mock_urlopen.call_args[0][0]
+        assert req.full_url == "http://localhost:28180/api/v1/dags"
+        assert req.method == "GET"
+
+    def test_get_with_params(self) -> None:
+        """Test GET request with query parameters."""
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.headers = {"Content-Type": "application/json"}
+        mock_response.read.return_value = b'{"dags": []}'
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_response) as mock_urlopen:
+            make_request("http://localhost:28180", "dags", params={"limit": 10, "only_active": "true"})
+
+        req = mock_urlopen.call_args[0][0]
+        assert "limit=10" in req.full_url
+        assert "only_active=true" in req.full_url
+
+    def test_post_with_json_body(self) -> None:
+        """Test POST request with JSON body."""
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.headers = {"Content-Type": "application/json"}
+        mock_response.read.return_value = b'{"key": "test"}'
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_response) as mock_urlopen:
+            make_request(
+                "http://localhost:28180",
+                "variables",
+                method="POST",
+                json_data={"key": "test", "value": "hello"},
+            )
+
+        req = mock_urlopen.call_args[0][0]
+        assert req.method == "POST"
+        assert req.data == b'{"key": "test", "value": "hello"}'
+        assert req.get_header("Content-type") == "application/json"
+
+    def test_raw_endpoint(self) -> None:
+        """Test raw endpoint (no /api/vX prefix)."""
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.headers = {}
+        mock_response.read.return_value = b'{"status": "healthy"}'
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_response) as mock_urlopen:
+            make_request("http://localhost:28180", "health", raw_endpoint=True)
+
+        req = mock_urlopen.call_args[0][0]
+        assert req.full_url == "http://localhost:28180/health"
+
+    def test_api_v2(self) -> None:
+        """Test API v2 URL construction."""
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.headers = {}
+        mock_response.read.return_value = b'{"dags": []}'
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_response) as mock_urlopen:
+            make_request("http://localhost:28180", "dags", api_version="v2")
+
+        req = mock_urlopen.call_args[0][0]
+        assert req.full_url == "http://localhost:28180/api/v2/dags"
+
+    def test_http_error(self) -> None:
+        """Test handling of HTTP errors."""
+        import urllib.error
+
+        error = urllib.error.HTTPError(
+            "http://localhost:28180/api/v1/dags",
+            404,
+            "Not Found",
+            {"Content-Type": "application/json"},
+            None,
+        )
+        error.read = MagicMock(return_value=b'{"detail": "not found"}')
+
+        with patch("urllib.request.urlopen", side_effect=error):
+            result = make_request("http://localhost:28180", "dags")
+
+        assert result["status_code"] == 404
+        assert result["body"] == {"detail": "not found"}
+
+    def test_connection_error(self) -> None:
+        """Test handling of connection errors."""
+        import urllib.error
+
+        error = urllib.error.URLError("Connection refused")
+
+        with patch("urllib.request.urlopen", side_effect=error):
+            result = make_request("http://localhost:28180", "dags")
+
+        assert result["status_code"] == 0
+        assert "Connection refused" in result["body"]["error"]
+
+    def test_auth_header(self) -> None:
+        """Test that Basic Auth header is set correctly."""
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.headers = {}
+        mock_response.read.return_value = b"{}"
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_response) as mock_urlopen:
+            make_request("http://localhost:28180", "dags", username="admin", password="secret")
+
+        req = mock_urlopen.call_args[0][0]
+        auth_header = req.get_header("Authorization")
+        assert auth_header is not None
+        assert auth_header.startswith("Basic ")
+
+        # Decode and verify credentials
+        import base64
+
+        decoded = base64.b64decode(auth_header.split(" ")[1]).decode()
+        assert decoded == "admin:secret"
+
+    def test_non_json_response(self) -> None:
+        """Test handling of non-JSON response body."""
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.headers = {"Content-Type": "text/plain"}
+        mock_response.read.return_value = b"OK"
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_response):
+            result = make_request("http://localhost:28180", "health", raw_endpoint=True)
+
+        assert result["status_code"] == 200
+        assert result["body"] == "OK"
+
+
+# ---------------------------------------------------------------------------
+# Tests for detect_api_version
+# ---------------------------------------------------------------------------
+
+
+class TestDetectApiVersion:
+    def test_detects_v2(self) -> None:
+        """Test detection of Airflow 3.x (v2 API)."""
+        with patch("airflow_breeze_manager.api.make_request") as mock_req:
+            mock_req.return_value = {"status_code": 200, "headers": {}, "body": {"version": "3.0.0"}}
+            version = detect_api_version("http://localhost:28180")
+
+        assert version == "v2"
+        # Should have tried v2 first
+        assert mock_req.call_args_list[0][1]["api_version"] == "v2"
+
+    def test_detects_v1(self) -> None:
+        """Test detection of Airflow 2.x (v1 API)."""
+        with patch("airflow_breeze_manager.api.make_request") as mock_req:
+            # v2 fails, v1 succeeds
+            mock_req.side_effect = [
+                {"status_code": 404, "headers": {}, "body": {}},
+                {"status_code": 200, "headers": {}, "body": {"version": "2.10.0"}},
+            ]
+            version = detect_api_version("http://localhost:28180")
+
+        assert version == "v1"
+
+    def test_defaults_to_v1(self) -> None:
+        """Test fallback to v1 when neither version responds."""
+        with patch("airflow_breeze_manager.api.make_request") as mock_req:
+            mock_req.return_value = {"status_code": 0, "headers": {}, "body": {}}
+            version = detect_api_version("http://localhost:28180")
+
+        assert version == "v1"
+
+
+# ---------------------------------------------------------------------------
+# Tests for format_endpoint_list
+# ---------------------------------------------------------------------------
+
+
+class TestFormatEndpointList:
+    @pytest.fixture
+    def sample_spec(self) -> dict:
+        return {
+            "paths": {
+                "/api/v1/dags": {
+                    "get": {"summary": "List DAGs"},
+                },
+                "/api/v1/dags/{dag_id}": {
+                    "get": {"summary": "Get a DAG"},
+                    "patch": {"summary": "Update a DAG"},
+                },
+                "/api/v1/variables": {
+                    "get": {"summary": "List variables"},
+                    "post": {"summary": "Create a variable"},
+                },
+                "/api/v1/variables/{variable_key}": {
+                    "get": {"summary": "Get a variable"},
+                    "patch": {"summary": "Update a variable"},
+                    "delete": {"summary": "Delete a variable"},
+                },
+            }
+        }
+
+    def test_list_all_endpoints(self, sample_spec: dict) -> None:
+        endpoints = format_endpoint_list(sample_spec)
+        assert len(endpoints) == 8
+        # Should be sorted by path
+        assert endpoints[0]["path"] == "/api/v1/dags"
+
+    def test_filter_endpoints(self, sample_spec: dict) -> None:
+        endpoints = format_endpoint_list(sample_spec, filter_pattern="variable")
+        assert len(endpoints) == 5
+        assert all("variable" in ep["path"].lower() for ep in endpoints)
+
+    def test_filter_no_match(self, sample_spec: dict) -> None:
+        endpoints = format_endpoint_list(sample_spec, filter_pattern="nonexistent")
+        assert endpoints == []
+
+    def test_endpoint_structure(self, sample_spec: dict) -> None:
+        endpoints = format_endpoint_list(sample_spec)
+        for ep in endpoints:
+            assert "method" in ep
+            assert "path" in ep
+            assert "summary" in ep
+            assert ep["method"] in ("GET", "POST", "PUT", "PATCH", "DELETE")
+
+    def test_empty_spec(self) -> None:
+        endpoints = format_endpoint_list({})
+        assert endpoints == []
+
+    def test_spec_with_no_paths(self) -> None:
+        endpoints = format_endpoint_list({"paths": {}})
+        assert endpoints == []
+
+
+# ---------------------------------------------------------------------------
+# Tests for CLI api command
+# ---------------------------------------------------------------------------
+
+
+class TestApiCommand:
+    def _create_project(self, projects_dir: Path) -> None:
+        """Helper to create a test project in the given directory."""
+        project_dir = projects_dir / "test-project"
+        project_dir.mkdir()
+        metadata = ProjectMetadata(
+            name="test-project",
+            branch="main",
+            worktree_path="/tmp/test-project",
+            ports=ProjectPorts.default(),
+            description="Test project",
+        )
+        with open(project_dir / ".abm", "w") as f:
+            json.dump(metadata.to_dict(), f)
+
+    def test_api_no_endpoint(self) -> None:
+        """Test api command with no endpoint shows error."""
+        result = runner.invoke(app, ["api"])
+        assert result.exit_code == 1
+
+    def test_api_get_request(self) -> None:
+        """Test basic GET request through CLI."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            projects_dir = Path(tmpdir) / "projects"
+            projects_dir.mkdir(parents=True)
+            self._create_project(projects_dir)
+
+            with (
+                patch("airflow_breeze_manager.utils.PROJECTS_DIR", projects_dir),
+                patch("airflow_breeze_manager.api.detect_api_version", return_value="v1"),
+                patch("airflow_breeze_manager.api.make_request") as mock_req,
+            ):
+                mock_req.return_value = {
+                    "status_code": 200,
+                    "headers": {"Content-Type": "application/json"},
+                    "body": {"dags": [], "total_entries": 0},
+                }
+                result = runner.invoke(app, ["api", "dags", "--project", "test-project"])
+
+            assert result.exit_code == 0
+
+    def test_api_connection_error(self) -> None:
+        """Test api command when Airflow is not running."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            projects_dir = Path(tmpdir) / "projects"
+            projects_dir.mkdir(parents=True)
+            self._create_project(projects_dir)
+
+            with (
+                patch("airflow_breeze_manager.utils.PROJECTS_DIR", projects_dir),
+                patch("airflow_breeze_manager.api.detect_api_version", return_value="v1"),
+                patch("airflow_breeze_manager.api.make_request") as mock_req,
+            ):
+                mock_req.return_value = {
+                    "status_code": 0,
+                    "headers": {},
+                    "body": {"error": "Connection refused"},
+                }
+                result = runner.invoke(app, ["api", "dags", "--project", "test-project"])
+
+            assert result.exit_code == 1
+            assert "Connection failed" in result.output
+
+    def test_api_json_mode(self) -> None:
+        """Test api command in JSON mode."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            projects_dir = Path(tmpdir) / "projects"
+            projects_dir.mkdir(parents=True)
+            self._create_project(projects_dir)
+
+            with (
+                patch("airflow_breeze_manager.utils.PROJECTS_DIR", projects_dir),
+                patch("airflow_breeze_manager.api.detect_api_version", return_value="v1"),
+                patch("airflow_breeze_manager.api.make_request") as mock_req,
+            ):
+                mock_req.return_value = {
+                    "status_code": 200,
+                    "headers": {"Content-Type": "application/json"},
+                    "body": {"dags": []},
+                }
+                result = runner.invoke(app, ["--json", "api", "dags", "--project", "test-project"])
+
+            assert result.exit_code == 0
+            output = json.loads(result.output)
+            assert output["success"] is True
+            assert output["data"]["status_code"] == 200
+            assert output["data"]["body"] == {"dags": []}
+
+    def test_api_ls_subcommand(self) -> None:
+        """Test api ls subcommand."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            projects_dir = Path(tmpdir) / "projects"
+            projects_dir.mkdir(parents=True)
+            self._create_project(projects_dir)
+
+            sample_spec = {
+                "paths": {
+                    "/api/v1/dags": {"get": {"summary": "List DAGs"}},
+                    "/api/v1/variables": {"get": {"summary": "List variables"}},
+                }
+            }
+
+            with (
+                patch("airflow_breeze_manager.utils.PROJECTS_DIR", projects_dir),
+                patch("airflow_breeze_manager.api.detect_api_version", return_value="v1"),
+                patch("airflow_breeze_manager.api.get_openapi_spec", return_value=sample_spec),
+            ):
+                result = runner.invoke(app, ["api", "ls", "--project", "test-project"])
+
+            assert result.exit_code == 0
+
+    def test_api_ls_json_mode(self) -> None:
+        """Test api ls subcommand in JSON mode."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            projects_dir = Path(tmpdir) / "projects"
+            projects_dir.mkdir(parents=True)
+            self._create_project(projects_dir)
+
+            sample_spec = {
+                "paths": {
+                    "/api/v1/dags": {"get": {"summary": "List DAGs"}},
+                }
+            }
+
+            with (
+                patch("airflow_breeze_manager.utils.PROJECTS_DIR", projects_dir),
+                patch("airflow_breeze_manager.api.detect_api_version", return_value="v1"),
+                patch("airflow_breeze_manager.api.get_openapi_spec", return_value=sample_spec),
+            ):
+                result = runner.invoke(app, ["--json", "api", "ls", "--project", "test-project"])
+
+            assert result.exit_code == 0
+            output = json.loads(result.output)
+            assert output["success"] is True
+            assert "endpoints" in output["data"]
+            assert len(output["data"]["endpoints"]) == 1
+
+    def test_api_with_fields_get(self) -> None:
+        """Test that -F fields become query params for GET requests."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            projects_dir = Path(tmpdir) / "projects"
+            projects_dir.mkdir(parents=True)
+            self._create_project(projects_dir)
+
+            with (
+                patch("airflow_breeze_manager.utils.PROJECTS_DIR", projects_dir),
+                patch("airflow_breeze_manager.api.detect_api_version", return_value="v1"),
+                patch("airflow_breeze_manager.api.make_request") as mock_req,
+            ):
+                mock_req.return_value = {
+                    "status_code": 200,
+                    "headers": {},
+                    "body": {"dags": []},
+                }
+                runner.invoke(
+                    app,
+                    ["api", "dags", "--project", "test-project", "-F", "limit=10", "-F", "only_active=true"],
+                )
+
+            # Verify params were passed (not json_data)
+            call_kwargs = mock_req.call_args[1]
+            assert call_kwargs["params"] == {"limit": 10, "only_active": True}
+            assert call_kwargs["json_data"] is None
+
+    def test_api_with_fields_post(self) -> None:
+        """Test that -f fields become JSON body for POST requests."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            projects_dir = Path(tmpdir) / "projects"
+            projects_dir.mkdir(parents=True)
+            self._create_project(projects_dir)
+
+            with (
+                patch("airflow_breeze_manager.utils.PROJECTS_DIR", projects_dir),
+                patch("airflow_breeze_manager.api.detect_api_version", return_value="v1"),
+                patch("airflow_breeze_manager.api.make_request") as mock_req,
+            ):
+                mock_req.return_value = {
+                    "status_code": 200,
+                    "headers": {},
+                    "body": {"key": "test"},
+                }
+                runner.invoke(
+                    app,
+                    [
+                        "api",
+                        "variables",
+                        "--project",
+                        "test-project",
+                        "-X",
+                        "POST",
+                        "-f",
+                        "key=test",
+                        "-f",
+                        "value=hello",
+                    ],
+                )
+
+            call_kwargs = mock_req.call_args[1]
+            assert call_kwargs["json_data"] == {"key": "test", "value": "hello"}
+            assert call_kwargs["params"] is None
+
+    def test_api_with_body(self) -> None:
+        """Test --body flag passes raw JSON."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            projects_dir = Path(tmpdir) / "projects"
+            projects_dir.mkdir(parents=True)
+            self._create_project(projects_dir)
+
+            with (
+                patch("airflow_breeze_manager.utils.PROJECTS_DIR", projects_dir),
+                patch("airflow_breeze_manager.api.detect_api_version", return_value="v1"),
+                patch("airflow_breeze_manager.api.make_request") as mock_req,
+            ):
+                mock_req.return_value = {
+                    "status_code": 200,
+                    "headers": {},
+                    "body": {},
+                }
+                runner.invoke(
+                    app,
+                    [
+                        "api",
+                        "dags/my_dag/dagRuns",
+                        "--project",
+                        "test-project",
+                        "-X",
+                        "POST",
+                        "--body",
+                        '{"conf": {}}',
+                    ],
+                )
+
+            call_kwargs = mock_req.call_args[1]
+            assert call_kwargs["json_data"] == {"conf": {}}
+
+    def test_api_raw_flag(self) -> None:
+        """Test --raw flag skips /api/vX prefix."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            projects_dir = Path(tmpdir) / "projects"
+            projects_dir.mkdir(parents=True)
+            self._create_project(projects_dir)
+
+            with (
+                patch("airflow_breeze_manager.utils.PROJECTS_DIR", projects_dir),
+                patch("airflow_breeze_manager.api.make_request") as mock_req,
+            ):
+                mock_req.return_value = {
+                    "status_code": 200,
+                    "headers": {},
+                    "body": {"status": "healthy"},
+                }
+                runner.invoke(
+                    app,
+                    ["api", "health", "--project", "test-project", "--raw"],
+                )
+
+            call_kwargs = mock_req.call_args[1]
+            assert call_kwargs["raw_endpoint"] is True
+
+    def test_api_include_headers(self) -> None:
+        """Test -i flag includes headers in output."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            projects_dir = Path(tmpdir) / "projects"
+            projects_dir.mkdir(parents=True)
+            self._create_project(projects_dir)
+
+            with (
+                patch("airflow_breeze_manager.utils.PROJECTS_DIR", projects_dir),
+                patch("airflow_breeze_manager.api.detect_api_version", return_value="v1"),
+                patch("airflow_breeze_manager.api.make_request") as mock_req,
+            ):
+                mock_req.return_value = {
+                    "status_code": 200,
+                    "headers": {"Content-Type": "application/json", "Server": "gunicorn"},
+                    "body": {"dags": []},
+                }
+                result = runner.invoke(
+                    app,
+                    ["api", "dags", "--project", "test-project", "-i"],
+                )
+
+            assert result.exit_code == 0
+            assert "HTTP 200" in result.output
+
+    def test_api_invalid_body_json(self) -> None:
+        """Test --body with invalid JSON shows error."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            projects_dir = Path(tmpdir) / "projects"
+            projects_dir.mkdir(parents=True)
+            self._create_project(projects_dir)
+
+            with (
+                patch("airflow_breeze_manager.utils.PROJECTS_DIR", projects_dir),
+                patch("airflow_breeze_manager.api.detect_api_version", return_value="v1"),
+            ):
+                result = runner.invoke(
+                    app,
+                    [
+                        "api",
+                        "dags",
+                        "--project",
+                        "test-project",
+                        "-X",
+                        "POST",
+                        "--body",
+                        "not-valid-json",
+                    ],
+                )
+
+            assert result.exit_code == 1
+            assert "Invalid JSON body" in result.output
+
+    def test_api_http_error_exit_code(self) -> None:
+        """Test that HTTP 4xx/5xx responses result in exit code 1."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            projects_dir = Path(tmpdir) / "projects"
+            projects_dir.mkdir(parents=True)
+            self._create_project(projects_dir)
+
+            with (
+                patch("airflow_breeze_manager.utils.PROJECTS_DIR", projects_dir),
+                patch("airflow_breeze_manager.api.detect_api_version", return_value="v1"),
+                patch("airflow_breeze_manager.api.make_request") as mock_req,
+            ):
+                mock_req.return_value = {
+                    "status_code": 404,
+                    "headers": {},
+                    "body": {"detail": "not found"},
+                }
+                result = runner.invoke(
+                    app,
+                    ["api", "dags/nonexistent", "--project", "test-project"],
+                )
+
+            assert result.exit_code == 1


### PR DESCRIPTION
## Summary

Adds an `abm api` command — like `gh api` for GitHub — that makes direct REST API calls to an ABM project's Airflow instance. ABM already knows the webserver port for each project, so this eliminates manual port lookup.

## Usage

```bash
# Basic GET (auto-detect project from cwd)
abm api dags
abm api dags/my_dag

# Explicit project
abm api dags --project my-feature

# HTTP methods + fields
abm api dags/my_dag -X PATCH -F is_paused=true
abm api variables -X POST -f key=my_var -f value=x

# Raw endpoint (no /api/vX prefix)
abm api health --raw

# Include HTTP headers in output
abm api dags -i

# List available endpoints from OpenAPI spec
abm api ls
abm api ls --filter variable

# Agent/JSON mode
abm --json api dags
```

## Design Rationale

- **stdlib `urllib` over `requests`**: Avoids relying on transitive dependency from `docker`. If `docker` ever drops `requests`, ABM still works. `urllib.request` is sufficient for simple JSON API calls.

- **Auto-detect API version**: Probes `/api/v2/version` first (Airflow 3.x), falls back to `/api/v1/version` (Airflow 2.x). Cached per invocation.

- **Field conventions from `gh api` / `af api`**: `-F` (typed, auto-coerces int/float/bool/null) and `-f` (raw string). GET requests put fields in query params; POST/PATCH/PUT put them in JSON body.

- **Default auth `airflow`/`airflow`**: Breeze dev environments use this. Override with `--username`/`--password`.

- **`ls` subcommand**: Fetches OpenAPI spec and lists endpoints with method + summary. Useful for discovery.

## Files Changed

| File | Change |
|------|--------|
| `src/airflow_breeze_manager/api.py` | **New** — HTTP client, field parsing, version detection, OpenAPI endpoint listing |
| `src/airflow_breeze_manager/cli.py` | Add `api` command with all options |
| `src/airflow_breeze_manager/output.py` | Add `API_ERROR` error code |
| `tests/test_api.py` | **New** — 44 unit tests covering all API module + CLI integration |